### PR TITLE
feat(Consumer): print header for any number of columns

### DIFF
--- a/src/metrics/print.rs
+++ b/src/metrics/print.rs
@@ -11,16 +11,13 @@ impl Consumer for Print {
         rx: &mut Receiver<Vec<String>>,
         column_names: Vec<String>,
     ) -> Result<(), String> {
-        println!(
-            "#\t{}\t{}\n------------------------------------------",
-            column_names[1], column_names[0]
-        );
+        println!("#,{}", column_names.join(","));
         let mut count = 1;
+
         while let Some(entry) = rx.recv().await {
-            println!("{}\t{}\t\t{}", count, &entry[1], &entry[0]);
+            println!("{},{}", count, entry.join(","));
             count += 1;
         }
-
         Ok(())
     }
 }


### PR DESCRIPTION
As discussed on Zulip, even if the reverse-ordered columns look nicer, we plan to use a pretty printer to solve the style issues.
Address https://github.com/optopodi/optopodi/issues/30 .
- [x] print header for any number of colums
- [x] default the output mode to CSV, so that it can be pretty-printed (and eventually stored in a file)
- [ ] escape `,` in entry content
- [ ] make a  `test producer` that supplies dummy data to test it