### PR TITLE
Fix name of clap app

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use crate::report::Report;
 
 #[derive(Clap, Debug, PartialEq)]
 #[clap(setting = AppSettings::ColoredHelp)]
-#[clap(name = "gh-metrics")]
+#[clap(name = "optopodi")]
 struct OctoCli {
     /// Load the saved results of grapql queries from disk (if they are present).
     #[clap(long)]


### PR DESCRIPTION
During my initial discovery of the code base I found that the Clap app name was `gh-metrics`. The name of the project was however changed from 'github-metrics' to 'optopodi' in commit 189af3d99. This name change is not yet reflected in the Clap app name, which is what this PR aims to rectify. 

The readme and book also still point to the github-metrics Zulip, but since the project actually chats in that instance (i.e. the Zulip instance has not been renamed), I did not change those.