### PR TITLE
feat: error-context

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -44,7 +44,7 @@ pub fn run_producer(
     tokio::spawn(async move {
         if let Err(e) = producer.producer_task(tx).await {
             println!("Encountered an error while collecting data: {}", e);
-        };
+        }
     });
 
     (column_names, rx)

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,6 +1,6 @@
 use fehler::throws;
 use stable_eyre::eyre;
-use stable_eyre::eyre::Error;
+use stable_eyre::eyre::{Error, WrapErr};
 
 /// Finds the token in the user's environment, panicking if no suitable token
 /// can be found.
@@ -10,7 +10,7 @@ pub fn github_token() -> String {
         return s;
     }
 
-    if let Some(s) = get_token_from_git_config()? {
+    if let Some(s) = get_token_from_git_config().wrap_err("Failed to get token from Git Config")? {
         return s;
     }
 
@@ -30,7 +30,8 @@ fn get_token_from_git_config() -> Option<String> {
         .arg("config")
         .arg("--get")
         .arg("github.oauth-token")
-        .output()?;
+        .output()
+        .wrap_err("Failed run `git config --get github.oauth-token`")?;
     if output.status.success() {
         let git_token = String::from_utf8(output.stdout)?.trim().to_string();
         Some(git_token)


### PR DESCRIPTION
## Description

Now that we've moved to `eyre` for Error handling, we just need to add context to our reports!

- [x] closes #44 
- [x] add context to errors thrown in `report` mod and `main` (and some other places, too)