### PR TITLE
Add Collaboration Guidelines to Contribution Guide

### DIFF
--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -64,8 +64,6 @@ Bob: No way. Windows is so easy to use that even my mom can use it.
 
 **And finally, not every comment requires a response.**
 
-We follow the [Rust code of conduct](https://www.rust-lang.org/policies/code-of-conduct). Please report any concerns to a [Lead][leads].
-
 ## Chat
 
 We chat on the github-metrics Zulip instance, found at <https://github-metrics.zulipchat.com/>.

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -14,7 +14,7 @@ Examples of behaviours that contribute to creating a positive environment:
 
 * Being friendly and patient  
 * Using welcoming and inclusive language  
-* eing respectful of differing viewpoints and experiences  
+* Being respectful of differing viewpoints and experiences  
 * Gracefully accepting constructive criticism
 * Focusing on what is best for the community
 * Showing empathy towards other community members

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -6,6 +6,66 @@ Want to help? Great! This is a fun project to hack on because it's relatively si
 
 We follow the [Rust code of conduct](https://www.rust-lang.org/policies/code-of-conduct). Please report any concerns to a [Lead][leads].
 
+## Optopodi Collaboration Guidelines
+
+Adopted from the [Mentored Sprints](https://www.mentored-sprints.dev) discord server and [The Recurse Social Rules](https://www.recurse.com/social-rules) these guidelines extend the [Rust CoC](https://www.rust-lang.org/policies/code-of-conduct) in ways that are actionable and clear examples to follow for the Optopodi team.
+```
+Examples of behaviours that contribute to creating a positive environment:
+
+Being friendly and patient
+Using welcoming and inclusive language
+Being respectful of differing viewpoints and experiences
+Gracefully accepting constructive criticism
+Focusing on what is best for the community
+Showing empathy towards other community members
+Examples of unacceptable behaviour by participants include:
+
+The use of sexualised or violent language or imagery
+Unwelcome sexual attention or advances
+Trolling, insulting/derogatory comments, and personal or political attacks
+Public or private harassment. If someone asks you to stop, then stop.
+Publishing others' private information, such as a physical or electronic address, without explicit permission
+Advocating for, or encouraging, any of the above behaviour
+Other conduct which could reasonably be considered inappropriate in a professional setting
+```
+
+The following are examples of good choices during collaboration with your team and choices to avoid.  The Recurse Center did such an excellent job creating these examples that addition explanation is not needed.
+
+**These guidelines aren’t for punishing people.**
+
+Consider these guidelines to be lightweight. You should not be afraid of breaking one. These are things that everyone does, and breaking one doesn’t make you a bad person. If someone says, "hey, you just feigned surprise," or "that’s subtly sexist," don’t worry. Just apologize, reflect for a second, and move on. 
+
+**Inclusive Language**  https://heyguys.cc/
+
+  Do use these terms: everyone, everybody, all, you all, y'all, folks, friends, people.
+
+⛔️ Do not use "guys"
+
+*No well-actually’s*
+
+>Alice: I just installed Linux on my computer!
+Bob: It’s actually called GNU/Linux.
+
+*No feigning surprise*
+
+>Dan: What’s the command line?
+Carol: Wait, you’ve never used the command line?
+
+*No backseat driving*
+
+>Bob: What’s the name of the string copy function?
+Alice: Strncpy.
+Eve: (injecting into an existing conversation) You should use strlcpy. It’s safer.
+
+*No subtle -isms*
+
+>Carol: Windows is hard to use.
+Bob: No way. Windows is so easy to use that even my mom can use it.
+
+**And finally, not every comment requires a response.**
+
+We follow the [Rust code of conduct](https://www.rust-lang.org/policies/code-of-conduct). Please report any concerns to a [Lead][leads].
+
 ## Chat
 
 We chat on the github-metrics Zulip instance, found at <https://github-metrics.zulipchat.com/>.

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -19,7 +19,7 @@ Examples of behaviours that contribute to creating a positive environment:
 * Focusing on what is best for the community
 * Showing empathy towards other community members
 * Examples of unacceptable behaviour by participants include:
-
+  
 * The use of sexualised or violent language or imagery
 * Unwelcome sexual attention or advances
 * Trolling, insulting/derogatory comments, and personal or political attacks
@@ -43,23 +43,23 @@ Consider these guidelines to be lightweight. You should not be afraid of breakin
 *No well-actually’s*
 
 >Alice: I just installed Linux on my computer!
-Bob: It’s actually called GNU/Linux.
+>Bob: It’s actually called GNU/Linux.
 
 *No feigning surprise*
 
 >Dan: What’s the command line?
-Carol: Wait, you’ve never used the command line?
+>Carol: Wait, you’ve never used the command line?
 
 *No backseat driving*
 
 >Bob: What’s the name of the string copy function?
-Alice: Strncpy.
-Eve: (injecting into an existing conversation) You should use strlcpy. It’s safer.
+>Alice: Strncpy.
+>Eve: (injecting into an existing conversation) You should use strlcpy. It’s safer.
 
 *No subtle -isms*
 
 >Carol: Windows is hard to use.
-Bob: No way. Windows is so easy to use that even my mom can use it.
+>Bob: No way. Windows is so easy to use that even my mom can use it.
 
 **And finally, not every comment requires a response.**
 

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -42,24 +42,24 @@ Consider these guidelines to be lightweight. You should not be afraid of breakin
 
 *No well-actually’s*
 
->Alice: I just installed Linux on my computer!
->Bob: It’s actually called GNU/Linux.
+> Alice: I just installed Linux on my computer!
+> Bob: It’s actually called GNU/Linux.
 
 *No feigning surprise*
 
->Dan: What’s the command line?
->Carol: Wait, you’ve never used the command line?
+> Dan: What’s the command line?
+> Carol: Wait, you’ve never used the command line?
 
 *No backseat driving*
 
->Bob: What’s the name of the string copy function?
->Alice: Strncpy.
->Eve: (injecting into an existing conversation) You should use strlcpy. It’s safer.
+> Bob: What’s the name of the string copy function?
+> Alice: Strncpy.
+> Eve: (injecting into an existing conversation) You should use strlcpy. It’s safer.
 
 *No subtle -isms*
 
->Carol: Windows is hard to use.
->Bob: No way. Windows is so easy to use that even my mom can use it.
+> Carol: Windows is hard to use.
+> Bob: No way. Windows is so easy to use that even my mom can use it.
 
 **And finally, not every comment requires a response.**
 

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -12,9 +12,9 @@ Adopted from the [Mentored Sprints](https://www.mentored-sprints.dev) discord se
 
 Examples of behaviours that contribute to creating a positive environment:
 
-* Being friendly and patient
-* Using welcoming and inclusive language
-* eing respectful of differing viewpoints and experiences
+* Being friendly and patient  
+* Using welcoming and inclusive language  
+* eing respectful of differing viewpoints and experiences  
 * Gracefully accepting constructive criticism
 * Focusing on what is best for the community
 * Showing empathy towards other community members

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -43,22 +43,27 @@ Consider these guidelines to be lightweight. You should not be afraid of breakin
 *No well-actually’s*
 
 > Alice: I just installed Linux on my computer!
+> 
 > Bob: It’s actually called GNU/Linux.
 
 *No feigning surprise*
 
 > Dan: What’s the command line?
+> 
 > Carol: Wait, you’ve never used the command line?
 
 *No backseat driving*
 
 > Bob: What’s the name of the string copy function?
+> 
 > Alice: Strncpy.
+> 
 > Eve: (injecting into an existing conversation) You should use strlcpy. It’s safer.
 
 *No subtle -isms*
 
 > Carol: Windows is hard to use.
+> 
 > Bob: No way. Windows is so easy to use that even my mom can use it.
 
 **And finally, not every comment requires a response.**

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -10,23 +10,24 @@ We follow the [Rust code of conduct](https://www.rust-lang.org/policies/code-of-
 
 Adopted from the [Mentored Sprints](https://www.mentored-sprints.dev) discord server and [The Recurse Social Rules](https://www.recurse.com/social-rules) these guidelines extend the [Rust CoC](https://www.rust-lang.org/policies/code-of-conduct) in ways that are actionable and clear examples to follow for the Optopodi team.
 
-Examples of unacceptable behaviors by participants include:
+Examples of behaviors that contribute to creating a positive environment:
 
-* Being friendly and patient  
-* Using welcoming and inclusive language  
-* Being respectful of differing viewpoints and experiences  
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
-* Examples of unacceptable behaviour by participants include:
+    * Being friendly and patient  
+    * Using welcoming and inclusive language  
+    * Being respectful of differing viewpoints and experiences  
+    * Gracefully accepting constructive criticism
+    * Focusing on what is best for the community
+    * Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
   
-* The use of sexualised or violent language or imagery
-* Unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment. If someone asks you to stop, then stop.
-* Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Advocating for, or encouraging, any of the above behaviour
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+    * The use of sexualised or violent language or imagery
+    * Unwelcome sexual attention or advances
+    * Trolling, insulting/derogatory comments, and personal or political attacks
+    * Public or private harassment. If someone asks you to stop, then stop.
+    * Publishing others' private information, such as a physical or electronic address, without explicit permission
+    * Advocating for, or encouraging, any of the above behaviour
+    * Other conduct which could reasonably be considered inappropriate in a professional setting
 
 The following are examples of good choices during collaboration with your team and choices to avoid.  The Recurse Center did such an excellent job creating these examples that addition explanation is not needed.
 

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -10,7 +10,7 @@ We follow the [Rust code of conduct](https://www.rust-lang.org/policies/code-of-
 
 Adopted from the [Mentored Sprints](https://www.mentored-sprints.dev) discord server and [The Recurse Social Rules](https://www.recurse.com/social-rules) these guidelines extend the [Rust CoC](https://www.rust-lang.org/policies/code-of-conduct) in ways that are actionable and clear examples to follow for the Optopodi team.
 
-Examples of behaviours that contribute to creating a positive environment:
+Examples of unacceptable behaviors by participants include:
 
 * Being friendly and patient  
 * Using welcoming and inclusive language  

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -12,21 +12,21 @@ Adopted from the [Mentored Sprints](https://www.mentored-sprints.dev) discord se
 
 Examples of behaviours that contribute to creating a positive environment:
 
-*Being friendly and patient  
-*Using welcoming and inclusive language  
-*Being respectful of differing viewpoints and experiences
-*Gracefully accepting constructive criticism
-*Focusing on what is best for the community
-*Showing empathy towards other community members
-*Examples of unacceptable behaviour by participants include:
+* Being friendly and patient
+* Using welcoming and inclusive language
+* eing respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+* Examples of unacceptable behaviour by participants include:
 
-*The use of sexualised or violent language or imagery
-*Unwelcome sexual attention or advances
-*Trolling, insulting/derogatory comments, and personal or political attacks
-*Public or private harassment. If someone asks you to stop, then stop.
-*Publishing others' private information, such as a physical or electronic address, without explicit permission
-*Advocating for, or encouraging, any of the above behaviour
-*Other conduct which could reasonably be considered inappropriate in a professional setting
+* The use of sexualised or violent language or imagery
+* Unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment. If someone asks you to stop, then stop.
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Advocating for, or encouraging, any of the above behaviour
+* Other conduct which could reasonably be considered inappropriate in a professional setting
 
 The following are examples of good choices during collaboration with your team and choices to avoid.  The Recurse Center did such an excellent job creating these examples that addition explanation is not needed.
 

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -9,25 +9,24 @@ We follow the [Rust code of conduct](https://www.rust-lang.org/policies/code-of-
 ## Optopodi Collaboration Guidelines
 
 Adopted from the [Mentored Sprints](https://www.mentored-sprints.dev) discord server and [The Recurse Social Rules](https://www.recurse.com/social-rules) these guidelines extend the [Rust CoC](https://www.rust-lang.org/policies/code-of-conduct) in ways that are actionable and clear examples to follow for the Optopodi team.
-```
+
 Examples of behaviours that contribute to creating a positive environment:
 
-Being friendly and patient
-Using welcoming and inclusive language
-Being respectful of differing viewpoints and experiences
-Gracefully accepting constructive criticism
-Focusing on what is best for the community
-Showing empathy towards other community members
-Examples of unacceptable behaviour by participants include:
+*Being friendly and patient  
+*Using welcoming and inclusive language  
+*Being respectful of differing viewpoints and experiences
+*Gracefully accepting constructive criticism
+*Focusing on what is best for the community
+*Showing empathy towards other community members
+*Examples of unacceptable behaviour by participants include:
 
-The use of sexualised or violent language or imagery
-Unwelcome sexual attention or advances
-Trolling, insulting/derogatory comments, and personal or political attacks
-Public or private harassment. If someone asks you to stop, then stop.
-Publishing others' private information, such as a physical or electronic address, without explicit permission
-Advocating for, or encouraging, any of the above behaviour
-Other conduct which could reasonably be considered inappropriate in a professional setting
-```
+*The use of sexualised or violent language or imagery
+*Unwelcome sexual attention or advances
+*Trolling, insulting/derogatory comments, and personal or political attacks
+*Public or private harassment. If someone asks you to stop, then stop.
+*Publishing others' private information, such as a physical or electronic address, without explicit permission
+*Advocating for, or encouraging, any of the above behaviour
+*Other conduct which could reasonably be considered inappropriate in a professional setting
 
 The following are examples of good choices during collaboration with your team and choices to avoid.  The Recurse Center did such an excellent job creating these examples that addition explanation is not needed.
 

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -12,22 +12,22 @@ Adopted from the [Mentored Sprints](https://www.mentored-sprints.dev) discord se
 
 Examples of behaviors that contribute to creating a positive environment:
 
-    * Being friendly and patient  
-    * Using welcoming and inclusive language  
-    * Being respectful of differing viewpoints and experiences  
-    * Gracefully accepting constructive criticism
-    * Focusing on what is best for the community
-    * Showing empathy towards other community members
+> * Being friendly and patient  
+> * Using welcoming and inclusive language  
+> * Being respectful of differing viewpoints and experiences  
+> * Gracefully accepting constructive criticism
+> * Focusing on what is best for the community
+> * Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
   
-    * The use of sexualised or violent language or imagery
-    * Unwelcome sexual attention or advances
-    * Trolling, insulting/derogatory comments, and personal or political attacks
-    * Public or private harassment. If someone asks you to stop, then stop.
-    * Publishing others' private information, such as a physical or electronic address, without explicit permission
-    * Advocating for, or encouraging, any of the above behaviour
-    * Other conduct which could reasonably be considered inappropriate in a professional setting
+> * The use of sexualised or violent language or imagery
+> * Unwelcome sexual attention or advances
+> * Trolling, insulting/derogatory comments, and personal or political attacks
+> * Public or private harassment. If someone asks you to stop, then stop.
+> * Publishing others' private information, such as a physical or electronic address, without explicit permission
+> * Advocating for, or encouraging, any of the above behaviour
+> * Other conduct which could reasonably be considered inappropriate in a professional setting
 
 The following are examples of good choices during collaboration with your team and choices to avoid.  The Recurse Center did such an excellent job creating these examples that addition explanation is not needed.
 


### PR DESCRIPTION
Include guidelines adopted from Mentored Sprints and The Recurse Center's Social Rules.  Some editorial freedoms applied.